### PR TITLE
Krl/oidc round three fixes

### DIFF
--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -780,7 +780,7 @@ class OAuth2Validator(RequestValidator):
             "alg": request.client.algorithm,
         }
         # PyJWKClient expects a kid in the header for varifying the token
-        if request.client.algorithm == oauth2_settings.OIDC_RSA_PRIVATE_KEY:
+        if request.client.algorithm == AbstractApplication.RS256_ALGORITHM:
             header["kid"] = request.client.jwk_key.thumbprint()
 
         jwt_token = jwt.JWT(

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -774,8 +774,17 @@ class OAuth2Validator(RequestValidator):
         if "nonce" not in id_token and request.nonce:
             id_token["nonce"] = request.nonce
 
+
+        header = {
+            "typ": "JWT",
+            "alg": request.client.algorithm,
+        }
+        # PyJWKClient expects a kid in the header for varifying the token
+        if request.client.algorithm == settings.OIDC_RSA_PRIVATE_KEY:
+            header["kid"] = request.client.jwk_key.thumbprint()
+
         jwt_token = jwt.JWT(
-            header=json.dumps({"alg": request.client.algorithm}, default=str),
+            header=json.dumps(header, default=str),
             claims=json.dumps(id_token, default=str),
         )
         jwt_token.make_signed_token(request.client.jwk_key)

--- a/oauth2_provider/oauth2_validators.py
+++ b/oauth2_provider/oauth2_validators.py
@@ -780,7 +780,7 @@ class OAuth2Validator(RequestValidator):
             "alg": request.client.algorithm,
         }
         # PyJWKClient expects a kid in the header for varifying the token
-        if request.client.algorithm == settings.OIDC_RSA_PRIVATE_KEY:
+        if request.client.algorithm == oauth2_settings.OIDC_RSA_PRIVATE_KEY:
             header["kid"] = request.client.jwk_key.thumbprint()
 
         jwt_token = jwt.JWT(


### PR DESCRIPTION
Hi @tevansuk 

I had trouble getting PyJWKClient to verify the id_token. It expected a key id (kid) in the header. The following change makes it possible for the PyJWKClient to verify the token. 

The "kid" is guarded by a check that the algorithm is RS256. I don't know if adding the kid should apply to other algorithms. 

ps. I'm currently running you branch in a test-environment and besides the kid issue everything is functioning OK . 

Cheers
Rune